### PR TITLE
Some adjustments

### DIFF
--- a/more/cors/main.py
+++ b/more/cors/main.py
@@ -77,7 +77,7 @@ def cors_settings():
         'expose_headers': ['Content-Type', 'Authorization'],
         'allowed_headers': ['Content-Type', 'Authorization'],
         'max_age': 60,
-        'allow_credentials': True
+        'allow_credentials': False
     }
 
 

--- a/more/cors/main.py
+++ b/more/cors/main.py
@@ -135,8 +135,8 @@ def cors_tween(app, handler):
 
         # Access-Control-Allow-Credentials
         allow_credentials = app.get_cors_allow_credentials(context, request)
-        response.headers.add('Access-Control-Allow-Credentials',
-                             str(allow_credentials).lower())
+        if allow_credentials is True:
+            response.headers.add('Access-Control-Allow-Credentials', 'true')
 
         if preflight:
             max_age = app.get_cors_max_age(context, request)

--- a/more/cors/main.py
+++ b/more/cors/main.py
@@ -127,6 +127,8 @@ def cors_tween(app, handler):
             allowed_origin = app.get_cors_allowed_origin(
                 context, request, requested_origin)
             response.headers.add('Access-Control-Allow-Origin', allowed_origin)
+            if allowed_origin and allowed_origin != '*':
+                response.headers.add('Vary', 'Origin')
 
         # Access-Control-Expose-Headers
         exposed_headers = app.get_cors_expose_headers(context, request)

--- a/more/cors/tests/test_cors.py
+++ b/more/cors/tests/test_cors.py
@@ -60,7 +60,7 @@ App.cors(
     allowed_headers=['Cache-Control'],
     expose_headers=['Cookie'],
     allowed_origin='http://localhost.localdomain',
-    allow_credentials=False,
+    allow_credentials=True,
     max_age=10
 )
 
@@ -91,7 +91,7 @@ def test_cors_preflight():
         'Access-Control-Expose-Headers').split(',') == ['Content-Type',
                                                         'Authorization']
 
-    assert r.headers.get('Access-Control-Allow-Credentials') == 'true'
+    assert r.headers.get('Access-Control-Allow-Credentials') is None
     assert r.headers.get('Access-Control-Max-Age') == '60'
 
 
@@ -109,7 +109,7 @@ def test_cors_override():
     assert r.headers.get(
         'Access-Control-Expose-Headers').split(',') == ['Cookie']
 
-    assert r.headers.get('Access-Control-Allow-Credentials') is None
+    assert r.headers.get('Access-Control-Allow-Credentials') == 'true'
     assert r.headers.get('Access-Control-Max-Age') == '10'
 
 
@@ -123,7 +123,7 @@ def test_cors_non_preflight():
         'Access-Control-Expose-Headers').split(',') == ['Content-Type',
                                                         'Authorization']
 
-    assert r.headers.get('Access-Control-Allow-Credentials') == 'true'
+    assert r.headers.get('Access-Control-Allow-Credentials') is None
     assert r.headers.get('Access-Control-Max-Age') is None
 
 

--- a/more/cors/tests/test_cors.py
+++ b/more/cors/tests/test_cors.py
@@ -109,7 +109,7 @@ def test_cors_override():
     assert r.headers.get(
         'Access-Control-Expose-Headers').split(',') == ['Cookie']
 
-    assert r.headers.get('Access-Control-Allow-Credentials') == 'false'
+    assert r.headers.get('Access-Control-Allow-Credentials') is None
     assert r.headers.get('Access-Control-Max-Age') == '10'
 
 


### PR DESCRIPTION
This PR do 3 things:
  * Omit the `Access-Control-Allow-Credentials` header when `allow_credentials` is not `True`.
    See [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials#Directives).
  * Set `Vary` header to 'Origin' when `allowed_origin` specifies a URI.
    See [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Examples).
  * Set `allow_credentials` by default to `False`.
    Specifying "*" as a wildcard for the `Access-Control-Allow-Origin` header is only allowed for
    [requests without credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Directives).
    So the default `'allowed_origin': '*'` and `'allow_credentials': True` are in conflict which each other.