### PR TITLE
Fix list of allowed verbs for failed (unauthorized) preflight

### DIFF
--- a/more/cors/main.py
+++ b/more/cors/main.py
@@ -1,5 +1,6 @@
 import morepath
 from morepath.publish import resolve_model, get_view_name
+from webob.exc import HTTPUnauthorized
 import dectate
 import reg
 from . import action
@@ -27,6 +28,8 @@ class App(morepath.App):
                       lambda self, model, request,
                       requested_method: request.view_name))
     def get_cors_allowed_methods(self, model, request, requested_method):
+        if model == None:
+            return self.settings.cors.allowed_verbs
         res = []
         for m in self.settings.cors.allowed_verbs:
             f = self.get_view.by_predicates(
@@ -92,7 +95,9 @@ def cors_tween(app, handler):
 
         try:
             context = resolve_model(request) or app
-        except Exception:
+        except HTTPUnauthorized:
+            context = None
+        except Exception as e:
             context = app
 
         _marker = []

--- a/more/cors/main.py
+++ b/more/cors/main.py
@@ -28,7 +28,7 @@ class App(morepath.App):
                       lambda self, model, request,
                       requested_method: request.view_name))
     def get_cors_allowed_methods(self, model, request, requested_method):
-        if model == None:
+        if model is None:
             return self.settings.cors.allowed_verbs
         res = []
         for m in self.settings.cors.allowed_verbs:
@@ -97,7 +97,7 @@ def cors_tween(app, handler):
             context = resolve_model(request) or app
         except HTTPUnauthorized:
             context = None
-        except Exception as e:
+        except Exception:
             context = app
 
         _marker = []

--- a/more/cors/tests/test_cors.py
+++ b/more/cors/tests/test_cors.py
@@ -1,5 +1,5 @@
 from webtest import TestApp as Client
-from webob.exc import HTTPUnauthorized 
+from webob.exc import HTTPUnauthorized
 import morepath
 from more.cors import CORSApp
 
@@ -144,7 +144,7 @@ def test_cors_unauthorized_preflight():
 
     assert r.headers.get(
         'Access-Control-Allow-Methods').split(',') \
-            == ['OPTIONS'] + c.app.settings.cors.allowed_verbs
+        == ['OPTIONS'] + c.app.settings.cors.allowed_verbs
 
 
 def test_cors_no_allowed_verbs():
@@ -168,4 +168,3 @@ def test_cors_failed_view():
     r = c.options('/failedobj', expect_errors=True)
 
     assert r.status_code == 404
-


### PR DESCRIPTION
During preflight (OPTIONS verb) no Authorization headers can be
provided. Some apps (see for example [this issue](https://github.com/yacoma/morepath-realworld-example-app/issues/1#issuecomment-396188110))
require these headers to determine the identity,
when solving a path and associating it with a model (eg: imagine that
the model is a User whose identity is in that header). Without that
information a sensible action for the path function is to raise
HTTPUnauthorized.

The problem is that more.cors treats that exception (and any exception)
in the same way during preflight: a 404 error is returned and no cors
headers. This prevents the browser to continue with the operation, which
could be otherwise legal.

This patch causes more.cors to return valid cors headers even if
the path function raised HTTPUnauthorized, instead of no cors headers.